### PR TITLE
Fixes for updated commons-compress library in upstream OpenSHA project

### DIFF
--- a/src/main/java/org/opensha/oaf/etas/AftershockStatsGUI_ETAS.java
+++ b/src/main/java/org/opensha/oaf/etas/AftershockStatsGUI_ETAS.java
@@ -6825,7 +6825,7 @@ public class AftershockStatsGUI_ETAS extends JFrame implements ParameterChangeLi
 		try{
 			lines = IOUtils.readLines(citiesIS, StandardCharsets.UTF_8);
 		} catch (Exception e) {
-			System.out.println("Couldn't load country border information: "+e.getMessage());
+			System.out.println("Couldn't load city information: "+e.getMessage());
 		}
 
 		//populate the feature list

--- a/src/main/java/org/opensha/oaf/etas/AftershockStatsGUI_ETAS.java
+++ b/src/main/java/org/opensha/oaf/etas/AftershockStatsGUI_ETAS.java
@@ -6824,8 +6824,8 @@ public class AftershockStatsGUI_ETAS extends JFrame implements ParameterChangeLi
 		List<String> lines = new ArrayList<String>();
 		try{
 			lines = IOUtils.readLines(citiesIS, StandardCharsets.UTF_8);
-		} catch (IOException e) {
-			System.out.println("Couldn't load city information");
+		} catch (Exception e) {
+			System.out.println("Couldn't load country border information: "+e.getMessage());
 		}
 
 		//populate the feature list
@@ -6862,8 +6862,8 @@ public class AftershockStatsGUI_ETAS extends JFrame implements ParameterChangeLi
 		List<String> lines = new ArrayList<String>();
 		try{
 			lines = IOUtils.readLines(bordersIS, StandardCharsets.UTF_8);
-		} catch (IOException e) {
-			System.out.println("Couldn't load country border information");
+		} catch (Exception e) {
+			System.out.println("Couldn't load country border information: "+e.getMessage());
 		}
 
 		ArrayList<XY_DataSet> countryBorders = new ArrayList<XY_DataSet>();


### PR DESCRIPTION
I just updated the Apache commons-compress library in the upstream OpenSHA project as part of https://github.com/opensha/opensha/pull/128. They introduced a breaking change that caused compile errors in `AftershockStatsGUI_ETAS`, notably that `IOUtils.readLines(InputStream, Charset)` no longer throws an IOException; instead it now throws an `UncheckedIOException` which is a `RuntimeException` if an I/O exception occurs.

This PR fixes that, and should also work with the old library if you merge it in before updating the upstream OpenSHA repo. I'll leave it to @mbarall or @nvanderelst to merge.