### PR TITLE
updated to use new point source class and include distance corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,4 @@ tmp
 Scratch*.java
 .DS_Store
 build.date
-build.githash
-build.gitbranch
+build.git*

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ ext {
 }
 
 apply from: '../opensha/build-common.gradle'
+apply from: '../opensha/build-git.gradle'
 
 dependencies {
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ ext {
 }
 
 apply from: '../opensha/build-common.gradle'
-apply from: '../opensha/build-git.gradle'
 
 dependencies {
 

--- a/src/main/java/org/opensha/oaf/etas/ETAS_ShakingForecastCalc.java
+++ b/src/main/java/org/opensha/oaf/etas/ETAS_ShakingForecastCalc.java
@@ -1,59 +1,46 @@
 package org.opensha.oaf.etas;
 
 import java.awt.geom.Point2D;
-import java.io.File;
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.swing.JFrame;
-
-import org.jfree.data.Range;
 import org.opensha.commons.data.Site;
 import org.opensha.commons.data.TimeSpan;
+import org.opensha.commons.data.WeightedList;
 import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
 import org.opensha.commons.data.function.DiscretizedFunc;
 import org.opensha.commons.data.siteData.SiteData;
-import org.opensha.commons.data.siteData.impl.WaldAllenGlobalVs30;
 import org.opensha.commons.data.xyz.ArbDiscrGeoDataSet;
 import org.opensha.commons.data.xyz.GeoDataSet;
 import org.opensha.commons.data.xyz.GriddedGeoDataSet;
 import org.opensha.commons.geo.GriddedRegion;
 import org.opensha.commons.geo.Location;
-import org.opensha.commons.geo.Region;
-import org.opensha.commons.gui.plot.jfreechart.xyzPlot.XYZPlotSpec;
-import org.opensha.commons.mapping.gmt.elements.GMT_CPT_Files;
 import org.opensha.commons.param.Parameter;
-import org.opensha.commons.util.cpt.CPT;
+import org.opensha.oaf.etas.griddedInterpGMPE.DistanceInterpolator;
+import org.opensha.oaf.etas.griddedInterpGMPE.DoubleParameterInterpolator;
+import org.opensha.oaf.etas.griddedInterpGMPE.GriddedInterpGMPE_Calc;
 import org.opensha.sha.calc.hazardMap.HazardDataSetLoader;
 import org.opensha.sha.earthquake.AbstractERF;
 import org.opensha.sha.earthquake.ProbEqkSource;
-import org.opensha.sha.earthquake.rupForecastImpl.PointSource13b;
+import org.opensha.sha.earthquake.rupForecastImpl.PointSourceNshm;
+import org.opensha.sha.faultSurface.utils.PointSourceDistanceCorrection;
+import org.opensha.sha.faultSurface.utils.PointSourceDistanceCorrections;
 import org.opensha.sha.gui.infoTools.IMT_Info;
-import org.opensha.sha.imr.AttenRelRef;
 import org.opensha.sha.imr.ScalarIMR;
-import org.opensha.sha.imr.attenRelImpl.calc.Wald_MMI_Calc;
-import org.opensha.sha.imr.param.IntensityMeasureParams.PGA_Param;
-import org.opensha.sha.imr.param.IntensityMeasureParams.PGV_Param;
-import org.opensha.sha.imr.param.IntensityMeasureParams.SA_Param;
 import org.opensha.sha.imr.param.SiteParams.Vs30_Param;
 import org.opensha.sha.magdist.GutenbergRichterMagFreqDist;
 import org.opensha.sha.util.FocalMech;
 
 import com.google.common.base.Preconditions;
 
-import org.opensha.oaf.etas.griddedInterpGMPE.DistanceInterpolator;
-import org.opensha.oaf.etas.griddedInterpGMPE.DoubleParameterInterpolator;
-import org.opensha.oaf.etas.griddedInterpGMPE.GriddedInterpGMPE_Calc;
-
 public class ETAS_ShakingForecastCalc {
 	
 	private static boolean D = false;
 	private static double magDelta = 0.1;
-	private static double[] depths = { 7, 2 }; // depth of <6.5 and >=6.5, respectively
+	private static final double MAG_CUT = 6.5;
+	private static double[] depths = { 7, 2 }; // depth of <MAG_CUT and >=MAG_CUT, respectively
 	
 	/**
 	 * 
@@ -192,6 +179,8 @@ public class ETAS_ShakingForecastCalc {
 		public void updateForecast() {
 			sources = new ArrayList<>();
 			
+			WeightedList<PointSourceDistanceCorrection> distCorrs = PointSourceDistanceCorrections.NSHM_2013.get();
+			
 			for (int i=0; i<rateModel.size(); i++) {
 				Location loc = rateModel.getLocation(i);
 				double rate = rateModel.get(i);
@@ -207,7 +196,7 @@ public class ETAS_ShakingForecastCalc {
 				else
 					mechWtMap = mechWts.get(i);
 				
-				PointSource13b source = new PointSource13b(loc, mfd, durationYears, depths, mechWtMap);
+				PointSourceNshm source = new PointSourceNshm(loc, mfd, durationYears, mechWtMap, MAG_CUT, depths[0], depths[1], distCorrs);
 				sources.add(source);
 			}
 		}


### PR DESCRIPTION
This updates the OAF project after a major refactor to how point sources are treated in the main project: https://github.com/opensha/opensha/pull/132

It makes the following changes to the ETAS aftershock hazard calculations:

* Switches to using `PointSourceNshm` over `PointSource13b`; they were basically identical and have been merged
* Now defaults to using the 2013 NSHM point source distance corrections, so that, e.g., when computing hazard for a large rupture, the distance used in the GMMs is the average distance of a spinning fault with that magnitude rather than the raw distance from the site to the grid cell. It looks like the prior code wasn't using any distance corrections, so this will change computed hazard (for the better).

I'm not sure how or if those calculations are used in production systems, so I'll leave it up to you to merge (but don't update the upstream project until you're ready to do so because there will be compile errors). 